### PR TITLE
Pass the canonical file path instead of a temp path.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Eslint_d(NodeLinter):
 
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)', 'jsx-real')
     npm_name = 'eslint_d'
-    cmd = ('eslint_d', '--no-ignore', '--format', 'compact', '@')
+    cmd = ('eslint_d', '--no-ignore', '--format', 'compact')
     executable = None
     version_args = '--version'
     version_re = r'eslint_d v(?P<version>\d+\.\d+\.\d+)'
@@ -39,7 +39,6 @@ class Eslint_d(NodeLinter):
     selectors = {
         'html': 'source.js.embedded.html'
     }
-    tempfile_suffix = 'js'
     config_file = ('--config', '.eslintrc', '~')
 
     def find_errors(self, output):
@@ -59,3 +58,10 @@ class Eslint_d(NodeLinter):
             return [(match, 0, None, "Error", "", msg, None)]
 
         return super().find_errors(output)
+
+    def communicate(self, cmd, code=None):
+        """Run an external executable using stdin to pass code and return its output."""
+
+        cmd.append(self.filename)
+
+        return super().communicate(cmd, code)


### PR DESCRIPTION
This fix allows ESLint plugins like [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to behave properly.

In the case of eslint-plugin-import, it needs the canonical path of the file to do its import resolving.
