### PR TITLE
pick one of the valid config files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -15,6 +15,10 @@ import os
 import re
 from SublimeLinter.lint import NodeLinter
 
+def get_config_file():
+    file_names = {'.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml',
+                  '.eslintrc.json', '.eslintrc', 'package.json'}
+    return next((n for n in file_names if os.path.isfile(n)), '.eslintrc')
 
 class Eslint_d(NodeLinter):
 
@@ -41,7 +45,7 @@ class Eslint_d(NodeLinter):
     selectors = {
         'html': 'source.js.embedded.html'
     }
-    config_file = ('--config', '.eslintrc', '~')
+    config_file = ('--config', get_config_file(), '~')
 
     def find_errors(self, output):
         """

--- a/linter.py
+++ b/linter.py
@@ -15,10 +15,19 @@ import os
 import re
 from SublimeLinter.lint import NodeLinter
 
+
 def get_config_file():
-    file_names = {'.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml',
-                  '.eslintrc.json', '.eslintrc', 'package.json'}
-    return next((n for n in file_names if os.path.isfile(n)), '.eslintrc')
+    """
+    Get the valid configuration file, as per the list of configuration files supported by ESLint.
+
+    This function iterates through a list of valid file names and check if the file actually exists. If it
+    does then return its name. If none of the file names exist then return the default value .eslintrc.
+    Refer: http://eslint.org/docs/user-guide/configuring#configuration-file-formats.
+    """
+
+    file_names = ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc', 'package.json']
+    return next((name for name in file_names if os.path.isfile(name)), '.eslintrc')
+
 
 class Eslint_d(NodeLinter):
 


### PR DESCRIPTION
ESLint supports more than one way to specify the configuration files.
The valid list of files can be seen here
http://eslint.org/docs/user-guide/configuring#configuration-file-formats
This patch checks if any of those files exist and if it does return that
file name, otherwise return `.eslintrc` as the default value.

Fixes: #12
